### PR TITLE
fix: align Node evt_/emk_ redaction with the Go CLI

### DIFF
--- a/plugins/agent-sdk/src/client.js
+++ b/plugins/agent-sdk/src/client.js
@@ -23,11 +23,10 @@ const noop = { info() {}, warn() {} };
  * accidentally lands in an error message (defense-in-depth, the same
  * shape evercli's output.redact uses).
  */
-// Token regex: case-insensitive on both alphabet AND prefix. Current
-// issuance is lowercase hex but defense-in-depth covers a future
-// alphabet change without us having to chase every log/error sink.
-const evtRe = /evt_[a-zA-Z0-9]{32}/g;
-const emkRe = /emk_[a-zA-Z0-9]{32}/g;
+// Match evercli's output.redact: ≥20 chars, tolerate _/- so a future
+// key-format change (and any non-32-char token) is still masked (#7).
+const evtRe = /evt_[A-Za-z0-9_\-]{20,}/g;
+const emkRe = /emk_[A-Za-z0-9_\-]{20,}/g;
 
 // AWS S3 presigned-POST / GET URLs carry short-lived but real
 // credentials. The query-string fields below are issued for ~15 min

--- a/plugins/agent-sdk/tests/client.test.js
+++ b/plugins/agent-sdk/tests/client.test.js
@@ -1,7 +1,7 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { createClient, EvermeError } from "../src/client.js";
+import { createClient, EvermeError, redactError } from "../src/client.js";
 
 /**
  * Helper: spin up a tiny HTTP server, return its base URL + a
@@ -108,6 +108,19 @@ describe("client", () => {
       assert.doesNotMatch(err.message, /evt_[a-f0-9]{32}/, "must not surface a full evt token");
       assert.match(err.message, /evt_aaaa_REDACTED/);
     }
+  });
+
+  test("redactError masks non-32-char and hyphenated evt_/emk_ tokens", async (t) => {
+    t.after(async () => s.close());
+    const hyphen = "evt_abcdefghij-klmnopqrs"; // 20+ with hyphen, used to leak
+    const shortish = "emk_" + "A".repeat(20);
+    const long = "evt_" + "b".repeat(40);
+    const got = redactError(`leaked ${hyphen} and ${shortish} and ${long}`);
+    assert.equal(got.includes(hyphen), false);
+    assert.equal(got.includes(shortish), false);
+    assert.equal(got.includes(long), false);
+    assert.match(got, /evt_abcd_REDACTED/);
+    assert.match(got, /emk_AAAA_REDACTED/);
   });
 
   test("query params are appended", async (t) => {


### PR DESCRIPTION
## Problem

`@everme/agent-sdk` only masked `evt_`/`emk_` tokens of exactly 32 alphanumeric characters. The Go CLI masks `{20,}` and allows `_`/`-`. Shorter, longer, or hyphenated tokens leaked into plugin logs and host LLM context.

Fixes #7.

## Change

Use the same pattern as `cli/internal/output/redact.go`.

## Test

```
node --test tests/client.test.js
# 7 pass
```
