### PR TITLE
ci: let the private-key scan skip the redactor regex literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,14 @@ jobs:
           # import redactor exists to *strip* credentials, so it necessarily
           # carries the PEM header pattern, and its fixtures are fabricated
           # placeholder bodies the test asserts get replaced.
+          # The plugin redactors (codex transcript.js and the everme/bin bundles
+          # built from it) carry the PEM header as a *regex literal*
+          # ("BEGIN [A-Z ]*PRIVATE KEY"). A real PEM header spells out the
+          # algorithm ("BEGIN RSA PRIVATE KEY"), so dropping the character-class
+          # form keeps the check exact while letting the redactor pattern through.
           if grep -R --exclude-dir=.git --exclude-dir=node_modules --exclude=ci.yml \
-            --exclude=redact.go --exclude=redact_test.go -n "BEGIN .*PRIVATE KEY" .; then
+            --exclude=redact.go --exclude=redact_test.go -n "BEGIN .*PRIVATE KEY" . \
+            | grep -v 'BEGIN \[A-Z \]\*PRIVATE KEY'; then
             echo "::error::Private key material detected"
             exit 1
           fi

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -1226,9 +1226,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1651,9 +1651,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
The codex transcript redactor and the everme/bin bundles built from it
carry the PEM header as a regex literal (BEGIN [A-Z ]*PRIVATE KEY). The
security job matched it as key material and has failed on every plugin
publish since 0.6.2. A real PEM header names the algorithm, so filtering
out the character-class form keeps the check exact.
